### PR TITLE
Remove size parameter from the constructor of 2D layers

### DIFF
--- a/NeuralNetworks.Test/LayeredNetworkModelTests.cs
+++ b/NeuralNetworks.Test/LayeredNetworkModelTests.cs
@@ -14,7 +14,7 @@ namespace Ivankarez.NeuralNetworks.Test
         {
             var inputMatrixSize = 125;
             var randomProvider = NN.Random.System(new Random(0));
-            var model = NN.Models.Layered(new Size2D(125, 125),
+            var model = NN.Models.Layered(NN.Size.Of(125, 125),
                     NN.Layers.Conv2D((5, 5), useBias: false, kernelInitializer:NN.Initializers.GlorotNormal(randomProvider)),
                     NN.Layers.Pooling2D((10, 10), (10, 10)),
                     NN.Layers.Dense(12*12, useBias: false, kernelInitializer: NN.Initializers.GlorotUniform(randomProvider)),

--- a/NeuralNetworks.Test/LayeredNetworkModelTests.cs
+++ b/NeuralNetworks.Test/LayeredNetworkModelTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Ivankarez.NeuralNetworks.Api;
 using Ivankarez.NeuralNetworks.RandomGeneration;
+using Ivankarez.NeuralNetworks.Utils;
 using NUnit.Framework;
 using System;
 
@@ -13,9 +14,9 @@ namespace Ivankarez.NeuralNetworks.Test
         {
             var inputMatrixSize = 125;
             var randomProvider = NN.Random.System(new Random(0));
-            var model = NN.Models.Layered(125 * 125,
-                    NN.Layers.Conv2D((125, 125), (5, 5), useBias: false, kernelInitializer:NN.Initializers.GlorotNormal(randomProvider)),
-                    NN.Layers.Pooling2D((121, 121), (10, 10), (10, 10)),
+            var model = NN.Models.Layered(new Size2D(125, 125),
+                    NN.Layers.Conv2D((5, 5), useBias: false, kernelInitializer:NN.Initializers.GlorotNormal(randomProvider)),
+                    NN.Layers.Pooling2D((10, 10), (10, 10)),
                     NN.Layers.Dense(12*12, useBias: false, kernelInitializer: NN.Initializers.GlorotUniform(randomProvider)),
                     NN.Layers.SimpleRecurrent(10, useBias: false, kernelInitializer: NN.Initializers.Normal(randomProvider: randomProvider)),
                     NN.Layers.Dense(3, kernelInitializer: NN.Initializers.Uniform(randomProvider: randomProvider), biasInitializer: NN.Initializers.Zeros())

--- a/NeuralNetworks.Test/Layers/Convolutional2dLayerTests.cs
+++ b/NeuralNetworks.Test/Layers/Convolutional2dLayerTests.cs
@@ -14,7 +14,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void Build_WithInvalidInputSize_ThrowsArgumentException()
         {
             var layer = NN.Layers.Conv2D((2, 2));
-            Action testAction = () => layer.Build(new Size1D(1));
+            Action testAction = () => layer.Build(NN.Size.Of(1));
             testAction.Should().Throw<ArgumentException>();
         }
 
@@ -22,8 +22,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void Build_WithValidInputSize_SetsNodeCount()
         {
             var layer = NN.Layers.Conv2D((2, 2), useBias: false);
-            layer.Build(new Size2D(3, 3));
-            layer.OutputSize.Should().Be(new Size2D(2, 2));
+            layer.Build(NN.Size.Of(3, 3));
+            layer.OutputSize.Should().Be(NN.Size.Of(2, 2));
             layer.Parameters.Get1dVector("biases").Should().BeEmpty();
         }
 
@@ -31,8 +31,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void Build_WithValidInputSize_UseBias()
         {
             var layer = NN.Layers.Conv2D((2, 2));
-            layer.Build(new Size2D(3, 3));
-            layer.OutputSize.Should().Be(new Size2D(2, 2));
+            layer.Build(NN.Size.Of(3, 3));
+            layer.OutputSize.Should().Be(NN.Size.Of(2, 2));
             layer.Parameters.Get1dVector("biases").Should().HaveCount(4);
         }
 
@@ -40,7 +40,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void Build_UseInitializer()
         {
             var layer = NN.Layers.Conv2D((2, 2), kernelInitializer: new ConstantInitializer(3f), biasInitializer: new ConstantInitializer(2));
-            layer.Build(new Size2D(3, 3));
+            layer.Build(NN.Size.Of(3, 3));
             layer.Parameters.Get2dVector("filter").Should().BeEquivalentTo(new float[,] { { 3, 3 }, { 3, 3 } });
             layer.Parameters.Get1dVector("biases").Should().OnlyContain(v => v == 2);
         }
@@ -49,7 +49,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void Build_WithValidInputSize_SetsNodeValues()
         {
             var layer = NN.Layers.Conv2D((2, 2), useBias: false);
-            layer.Build(new Size2D(3, 3));
+            layer.Build(NN.Size.Of(3, 3));
             layer.State.Get1dVector("nodeValues").Should().HaveCount(4);
         }
 
@@ -57,7 +57,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void Update_WithZeros()
         {
             var layer = NN.Layers.Conv2D((2, 2), useBias: false);
-            layer.Build(new Size2D(3, 3));
+            layer.Build(NN.Size.Of(3, 3));
             var output = layer.Update(new float[9]);
             output.Should().OnlyContain(v => v == 0);
         }
@@ -66,7 +66,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void Update_WithData()
         {
             var layer = NN.Layers.Conv2D((2, 2), useBias: false);
-            layer.Build(new Size2D(3, 3));
+            layer.Build(NN.Size.Of(3, 3));
 
             layer.Parameters.Get2dVector("filter").Fill(new float[,] { { -1, 2, }, { -2, 3 } });
             var input = new float[] { 1, 2, 3, -1, -2, -3, 1, 2, 3 };
@@ -79,7 +79,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void Update_WithData2()
         {
             var layer = NN.Layers.Conv2D((3, 3), useBias: false);
-            layer.Build(new Size2D(3, 3));
+            layer.Build(NN.Size.Of(3, 3));
 
             layer.Parameters.Get2dVector("filter").Fill(new float[,] { { 1, 1, 1 }, { 2, 2, 2 }, { 3, 3, 3 } });
             var input = new float[] { 1, 2, 3, -1, -2, -3, 1, 2, 3 };
@@ -92,7 +92,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void Update_WithData_LargerInput()
         {
             var layer = NN.Layers.Conv2D((11, 11), (5, 5), false);
-            layer.Build(new Size2D(90, 90));
+            layer.Build(NN.Size.Of(90, 90));
 
             var filter = RandomTestUtils.CreateRandomFloatMatrix(11, 11, 0);
             layer.Parameters.Get2dVector("filter").Fill(filter);
@@ -105,7 +105,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void Update_WithBias()
         {
             var layer = NN.Layers.Conv2D((2, 2), kernelInitializer: new ConstantInitializer(1), biasInitializer: new ConstantInitializer(2));
-            layer.Build(new Size2D(3, 3));
+            layer.Build(NN.Size.Of(3, 3));
 
             var output = layer.Update(new float[] {
                 1, 2, 3,

--- a/NeuralNetworks.Test/Layers/Convolutional2dLayerTests.cs
+++ b/NeuralNetworks.Test/Layers/Convolutional2dLayerTests.cs
@@ -13,34 +13,34 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         [Test]
         public void Build_WithInvalidInputSize_ThrowsArgumentException()
         {
-            var layer = NN.Layers.Conv2D((3, 3), (2, 2));
-            Action testAction = () => layer.Build(4);
+            var layer = NN.Layers.Conv2D((2, 2));
+            Action testAction = () => layer.Build(new Size1D(1));
             testAction.Should().Throw<ArgumentException>();
         }
 
         [Test]
         public void Build_WithValidInputSize_SetsNodeCount()
         {
-            var layer = NN.Layers.Conv2D((3, 3), (2, 2), useBias: false);
-            layer.Build(9);
-            layer.NodeCount.Should().Be(4);
+            var layer = NN.Layers.Conv2D((2, 2), useBias: false);
+            layer.Build(new Size2D(3, 3));
+            layer.OutputSize.Should().Be(new Size2D(2, 2));
             layer.Parameters.Get1dVector("biases").Should().BeEmpty();
         }
 
         [Test]
         public void Build_WithValidInputSize_UseBias()
         {
-            var layer = NN.Layers.Conv2D((3, 3), (2, 2));
-            layer.Build(9);
-            layer.NodeCount.Should().Be(4);
+            var layer = NN.Layers.Conv2D((2, 2));
+            layer.Build(new Size2D(3, 3));
+            layer.OutputSize.Should().Be(new Size2D(2, 2));
             layer.Parameters.Get1dVector("biases").Should().HaveCount(4);
         }
 
         [Test]
         public void Build_UseInitializer()
         {
-            var layer = NN.Layers.Conv2D((3, 3), (2, 2), kernelInitializer: new ConstantInitializer(3f), biasInitializer: new ConstantInitializer(2));
-            layer.Build(9);
+            var layer = NN.Layers.Conv2D((2, 2), kernelInitializer: new ConstantInitializer(3f), biasInitializer: new ConstantInitializer(2));
+            layer.Build(new Size2D(3, 3));
             layer.Parameters.Get2dVector("filter").Should().BeEquivalentTo(new float[,] { { 3, 3 }, { 3, 3 } });
             layer.Parameters.Get1dVector("biases").Should().OnlyContain(v => v == 2);
         }
@@ -48,16 +48,16 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         [Test]
         public void Build_WithValidInputSize_SetsNodeValues()
         {
-            var layer = NN.Layers.Conv2D((3, 3), (2, 2), useBias: false);
-            layer.Build(9);
+            var layer = NN.Layers.Conv2D((2, 2), useBias: false);
+            layer.Build(new Size2D(3, 3));
             layer.State.Get1dVector("nodeValues").Should().HaveCount(4);
         }
 
         [Test]
         public void Update_WithZeros()
         {
-            var layer = NN.Layers.Conv2D((3, 3), (2, 2), useBias: false);
-            layer.Build(9);
+            var layer = NN.Layers.Conv2D((2, 2), useBias: false);
+            layer.Build(new Size2D(3, 3));
             var output = layer.Update(new float[9]);
             output.Should().OnlyContain(v => v == 0);
         }
@@ -65,8 +65,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         [Test]
         public void Update_WithData()
         {
-            var layer = NN.Layers.Conv2D((3, 3), (2, 2), useBias: false);
-            layer.Build(9);
+            var layer = NN.Layers.Conv2D((2, 2), useBias: false);
+            layer.Build(new Size2D(3, 3));
 
             layer.Parameters.Get2dVector("filter").Fill(new float[,] { { -1, 2, }, { -2, 3 } });
             var input = new float[] { 1, 2, 3, -1, -2, -3, 1, 2, 3 };
@@ -78,8 +78,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         [Test]
         public void Update_WithData2()
         {
-            var layer = NN.Layers.Conv2D((3, 3), (3, 3), useBias: false);
-            layer.Build(9);
+            var layer = NN.Layers.Conv2D((3, 3), useBias: false);
+            layer.Build(new Size2D(3, 3));
 
             layer.Parameters.Get2dVector("filter").Fill(new float[,] { { 1, 1, 1 }, { 2, 2, 2 }, { 3, 3, 3 } });
             var input = new float[] { 1, 2, 3, -1, -2, -3, 1, 2, 3 };
@@ -91,8 +91,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         [Test]
         public void Update_WithData_LargerInput()
         {
-            var layer = NN.Layers.Conv2D((90, 90), (11, 11), (5, 5), false);
-            layer.Build(90 * 90);
+            var layer = NN.Layers.Conv2D((11, 11), (5, 5), false);
+            layer.Build(new Size2D(90, 90));
 
             var filter = RandomTestUtils.CreateRandomFloatMatrix(11, 11, 0);
             layer.Parameters.Get2dVector("filter").Fill(filter);
@@ -104,8 +104,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         [Test]
         public void Update_WithBias()
         {
-            var layer = NN.Layers.Conv2D((3, 3), (2, 2), kernelInitializer: new ConstantInitializer(1), biasInitializer: new ConstantInitializer(2));
-            layer.Build(9);
+            var layer = NN.Layers.Conv2D((2, 2), kernelInitializer: new ConstantInitializer(1), biasInitializer: new ConstantInitializer(2));
+            layer.Build(new Size2D(3, 3));
 
             var output = layer.Update(new float[] {
                 1, 2, 3,

--- a/NeuralNetworks.Test/Layers/ConvolutionalLayerTests.cs
+++ b/NeuralNetworks.Test/Layers/ConvolutionalLayerTests.cs
@@ -14,7 +14,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         {
             var layer = NN.Layers.Conv1D(3, useBias: false);
 
-            layer.Build(new Size1D(3));
+            layer.Build(NN.Size.Of(3));
 
             layer.Parameters.Get1dVector("filter").Should().HaveCount(3);
             layer.State.Get1dVector("nodeValues").Should().HaveCount(1);
@@ -24,7 +24,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestBuild_UseInitializer()
         {
             var layer = NN.Layers.Conv1D(3, kernelInitializer: new ConstantInitializer(3f), biasInitializer: new ConstantInitializer(2f));
-            layer.Build(new Size1D(3));
+            layer.Build(NN.Size.Of(3));
             layer.Parameters.Get1dVector("filter").Should().AllBeEquivalentTo(3);
             layer.Parameters.Get1dVector("biases").Should().AllBeEquivalentTo(2);
         }
@@ -34,7 +34,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         {
             var layer = NN.Layers.Conv1D(4);
 
-            Action callAction = () => layer.Build(new Size1D(3));
+            Action callAction = () => layer.Build(NN.Size.Of(3));
 
             callAction.Should().Throw<ArgumentException>();
         }
@@ -50,7 +50,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_SingleKernel()
         {
             var layer = NN.Layers.Conv1D(3, useBias: false);
-            layer.Build(new Size1D(3));
+            layer.Build(NN.Size.Of(3));
             layer.Parameters.Get1dVector("filter").Fill(1, 2, -1);
 
             var result = layer.Update(new float[] { 3, -5, -4 });
@@ -63,7 +63,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_MultipleKernel()
         {
             var layer = NN.Layers.Conv1D(2, useBias: false);
-            layer.Build(new Size1D(6));
+            layer.Build(NN.Size.Of(6));
             layer.Parameters.Get1dVector("filter").Fill(1, -2);
 
             var result = layer.Update(new float[] { 3, -5, -4, 2, 3, 1 });
@@ -80,7 +80,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_ShortestFilter()
         {
             var layer = NN.Layers.Conv1D(1, useBias: false);
-            layer.Build(new Size1D(3));
+            layer.Build(NN.Size.Of(3));
             layer.Parameters.Get1dVector("filter").Fill(.5f);
 
             var result = layer.Update(new float[] { 3, -5, 0 });
@@ -95,7 +95,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_UseBias()
         {
             var layer = NN.Layers.Conv1D(2, kernelInitializer: new ConstantInitializer(1), biasInitializer: new ConstantInitializer(2));
-            layer.Build(new Size1D(4));
+            layer.Build(NN.Size.Of(4));
 
             var result = layer.Update(new float[] { 3, -5, -4, 2 });
             result.Should().HaveCount(3);
@@ -106,7 +106,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_WithStride()
         {
             var layer = NN.Layers.Conv1D(2, stride: 2, useBias: false);
-            layer.Build(new Size1D(6));
+            layer.Build(NN.Size.Of(6));
             layer.Parameters.Get1dVector("filter").Fill(1, -2);
             var result = layer.Update(new[] { 3f, -5f, -4f, 2f, 3f, 1f });
             result.Should().BeEquivalentTo(new[] { 13f, -8f, 1f });

--- a/NeuralNetworks.Test/Layers/ConvolutionalLayerTests.cs
+++ b/NeuralNetworks.Test/Layers/ConvolutionalLayerTests.cs
@@ -14,7 +14,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         {
             var layer = NN.Layers.Conv1D(3, useBias: false);
 
-            layer.Build(3);
+            layer.Build(new Size1D(3));
 
             layer.Parameters.Get1dVector("filter").Should().HaveCount(3);
             layer.State.Get1dVector("nodeValues").Should().HaveCount(1);
@@ -24,7 +24,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestBuild_UseInitializer()
         {
             var layer = NN.Layers.Conv1D(3, kernelInitializer: new ConstantInitializer(3f), biasInitializer: new ConstantInitializer(2f));
-            layer.Build(3);
+            layer.Build(new Size1D(3));
             layer.Parameters.Get1dVector("filter").Should().AllBeEquivalentTo(3);
             layer.Parameters.Get1dVector("biases").Should().AllBeEquivalentTo(2);
         }
@@ -34,7 +34,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         {
             var layer = NN.Layers.Conv1D(4);
 
-            Action callAction = () => layer.Build(3);
+            Action callAction = () => layer.Build(new Size1D(3));
 
             callAction.Should().Throw<ArgumentException>();
         }
@@ -50,7 +50,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_SingleKernel()
         {
             var layer = NN.Layers.Conv1D(3, useBias: false);
-            layer.Build(3);
+            layer.Build(new Size1D(3));
             layer.Parameters.Get1dVector("filter").Fill(1, 2, -1);
 
             var result = layer.Update(new float[] { 3, -5, -4 });
@@ -63,7 +63,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_MultipleKernel()
         {
             var layer = NN.Layers.Conv1D(2, useBias: false);
-            layer.Build(6);
+            layer.Build(new Size1D(6));
             layer.Parameters.Get1dVector("filter").Fill(1, -2);
 
             var result = layer.Update(new float[] { 3, -5, -4, 2, 3, 1 });
@@ -80,7 +80,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_ShortestFilter()
         {
             var layer = NN.Layers.Conv1D(1, useBias: false);
-            layer.Build(3);
+            layer.Build(new Size1D(3));
             layer.Parameters.Get1dVector("filter").Fill(.5f);
 
             var result = layer.Update(new float[] { 3, -5, 0 });
@@ -95,7 +95,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_UseBias()
         {
             var layer = NN.Layers.Conv1D(2, kernelInitializer: new ConstantInitializer(1), biasInitializer: new ConstantInitializer(2));
-            layer.Build(4);
+            layer.Build(new Size1D(4));
 
             var result = layer.Update(new float[] { 3, -5, -4, 2 });
             result.Should().HaveCount(3);
@@ -106,7 +106,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_WithStride()
         {
             var layer = NN.Layers.Conv1D(2, stride: 2, useBias: false);
-            layer.Build(6);
+            layer.Build(new Size1D(6));
             layer.Parameters.Get1dVector("filter").Fill(1, -2);
             var result = layer.Update(new[] { 3f, -5f, -4f, 2f, 3f, 1f });
             result.Should().BeEquivalentTo(new[] { 13f, -8f, 1f });

--- a/NeuralNetworks.Test/Layers/DenseLayerTests.cs
+++ b/NeuralNetworks.Test/Layers/DenseLayerTests.cs
@@ -14,7 +14,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         {
             var initializer = new ZerosInitializer();
             var layer = new DenseLayer(2, new LinearActivation(), false, initializer, initializer);
-            layer.Build(new Size1D(1));
+            layer.Build(NN.Size.Of(1));
             layer.Parameters.Get2dVector("weights").Fill(new float[,] { { -1f }, { 2.3f } });
 
             var result = layer.Update(new float[] { 2f });
@@ -29,7 +29,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         {
             var initializer = new ZerosInitializer();
             var layer = new DenseLayer(3, new LinearActivation(), false, initializer, initializer);
-            layer.Build(new Size1D(2));
+            layer.Build(NN.Size.Of(2));
             layer.Parameters.Get2dVector("weights").Fill(new float[,] { { -1f, 2.3f }, { 1.34f, .5f }, { -.34f, .2f } });
 
             var result = layer.Update(new float[] { 2f, -.5f });
@@ -45,7 +45,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         {
             var initializer = new ZerosInitializer();
             var layer = new DenseLayer(2, new LinearActivation(), true, initializer, initializer);
-            layer.Build(new Size1D(1));
+            layer.Build(NN.Size.Of(1));
             layer.Parameters.Get1dVector("biases").Fill(.5f, -.23f);
 
             var result = layer.Update(new float[] { 2f });
@@ -61,7 +61,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
             var kernelInitializer = new ConstantInitializer(1);
             var biasInitializer = new ConstantInitializer(2);
             var layer = new DenseLayer(2, new LinearActivation(), true, kernelInitializer, biasInitializer);
-            layer.Build(new Size1D(10));
+            layer.Build(NN.Size.Of(10));
 
             var weights = layer.Parameters.Get2dVector("weights");
             for (int x = 0; x < weights.GetLength(0); x++)

--- a/NeuralNetworks.Test/Layers/DenseLayerTests.cs
+++ b/NeuralNetworks.Test/Layers/DenseLayerTests.cs
@@ -14,7 +14,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         {
             var initializer = new ZerosInitializer();
             var layer = new DenseLayer(2, new LinearActivation(), false, initializer, initializer);
-            layer.Build(1);
+            layer.Build(new Size1D(1));
             layer.Parameters.Get2dVector("weights").Fill(new float[,] { { -1f }, { 2.3f } });
 
             var result = layer.Update(new float[] { 2f });
@@ -29,7 +29,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         {
             var initializer = new ZerosInitializer();
             var layer = new DenseLayer(3, new LinearActivation(), false, initializer, initializer);
-            layer.Build(2);
+            layer.Build(new Size1D(2));
             layer.Parameters.Get2dVector("weights").Fill(new float[,] { { -1f, 2.3f }, { 1.34f, .5f }, { -.34f, .2f } });
 
             var result = layer.Update(new float[] { 2f, -.5f });
@@ -45,7 +45,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         {
             var initializer = new ZerosInitializer();
             var layer = new DenseLayer(2, new LinearActivation(), true, initializer, initializer);
-            layer.Build(1);
+            layer.Build(new Size1D(1));
             layer.Parameters.Get1dVector("biases").Fill(.5f, -.23f);
 
             var result = layer.Update(new float[] { 2f });
@@ -61,7 +61,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
             var kernelInitializer = new ConstantInitializer(1);
             var biasInitializer = new ConstantInitializer(2);
             var layer = new DenseLayer(2, new LinearActivation(), true, kernelInitializer, biasInitializer);
-            layer.Build(10);
+            layer.Build(new Size1D(10));
 
             var weights = layer.Parameters.Get2dVector("weights");
             for (int x = 0; x < weights.GetLength(0); x++)

--- a/NeuralNetworks.Test/Layers/DenseLayerTests.cs
+++ b/NeuralNetworks.Test/Layers/DenseLayerTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Ivankarez.NeuralNetworks.Activations;
+using Ivankarez.NeuralNetworks.Api;
 using Ivankarez.NeuralNetworks.Layers;
 using Ivankarez.NeuralNetworks.RandomGeneration.Initializers;
 using Ivankarez.NeuralNetworks.Utils;

--- a/NeuralNetworks.Test/Layers/Pooling2dLayerTests.cs
+++ b/NeuralNetworks.Test/Layers/Pooling2dLayerTests.cs
@@ -13,7 +13,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void Build_HappyPath()
         {
             var layer = new Pooling2dLayer((2, 2), (1, 1), PoolingType.Max);
-            layer.Build(new Size2D(3, 3));
+            layer.Build(NN.Size.Of(3, 3));
             layer.State.Get1dVector("nodeValues").Should().HaveCount(4);
             layer.Parameters.Get1dVectorNames().Should().BeEmpty();
             layer.Parameters.Get2dVectorNames().Should().BeEmpty();
@@ -23,7 +23,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void Build_InvalidInputSize()
         {
             var layer = new Pooling2dLayer((2, 2), (1, 1), PoolingType.Max);
-            layer.Invoking(l => l.Build(new Size1D(10))).Should().Throw<ArgumentException>();
+            layer.Invoking(l => l.Build(NN.Size.Of(10))).Should().Throw<ArgumentException>();
         }
 
         [TestCase(PoolingType.Min, new float[] { -2, -3, 0, -9 })]
@@ -33,7 +33,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void Update_HappyPath(PoolingType poolingType, float[] expectedResults)
         {
             var layer = new Pooling2dLayer((2, 2), (1, 1), poolingType);
-            layer.Build(new Size2D(3, 3));
+            layer.Build(NN.Size.Of(3, 3));
             var inputs = new float[] {
                 -1, -2, -3,
                 1, 2, 3,
@@ -47,7 +47,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void Update_CheckStride()
         {
             var layer = NN.Layers.Pooling2D((2, 2), (2, 3));
-            layer.Build(new Size2D(5, 6));
+            layer.Build(NN.Size.Of(5, 6));
 
             var inputs = new float[] { 
                 0, 1, 0, 1, 2,

--- a/NeuralNetworks.Test/Layers/Pooling2dLayerTests.cs
+++ b/NeuralNetworks.Test/Layers/Pooling2dLayerTests.cs
@@ -12,8 +12,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         [Test]
         public void Build_HappyPath()
         {
-            var layer = new Pooling2dLayer((3, 3), (2, 2), (1, 1), PoolingType.Max);
-            layer.Build(9);
+            var layer = new Pooling2dLayer((2, 2), (1, 1), PoolingType.Max);
+            layer.Build(new Size2D(3, 3));
             layer.State.Get1dVector("nodeValues").Should().HaveCount(4);
             layer.Parameters.Get1dVectorNames().Should().BeEmpty();
             layer.Parameters.Get2dVectorNames().Should().BeEmpty();
@@ -22,8 +22,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         [Test]
         public void Build_InvalidInputSize()
         {
-            var layer = new Pooling2dLayer((3, 3), (2, 2), (1, 1), PoolingType.Max);
-            layer.Invoking(l => l.Build(10)).Should().Throw<ArgumentException>();
+            var layer = new Pooling2dLayer((2, 2), (1, 1), PoolingType.Max);
+            layer.Invoking(l => l.Build(new Size1D(10))).Should().Throw<ArgumentException>();
         }
 
         [TestCase(PoolingType.Min, new float[] { -2, -3, 0, -9 })]
@@ -32,8 +32,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         [TestCase(PoolingType.Sum, new float[] { 0, 0, 12, 5 })]
         public void Update_HappyPath(PoolingType poolingType, float[] expectedResults)
         {
-            var layer = new Pooling2dLayer((3, 3), (2, 2), (1, 1), poolingType);
-            layer.Build(9);
+            var layer = new Pooling2dLayer((2, 2), (1, 1), poolingType);
+            layer.Build(new Size2D(3, 3));
             var inputs = new float[] {
                 -1, -2, -3,
                 1, 2, 3,
@@ -46,8 +46,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         [Test]
         public void Update_CheckStride()
         {
-            var layer = NN.Layers.Pooling2D((5, 6), (2, 2), (2, 3));
-            layer.Build(30);
+            var layer = NN.Layers.Pooling2D((2, 2), (2, 3));
+            layer.Build(new Size2D(5, 6));
 
             var inputs = new float[] { 
                 0, 1, 0, 1, 2,

--- a/NeuralNetworks.Test/Layers/PoolingLayerTests.cs
+++ b/NeuralNetworks.Test/Layers/PoolingLayerTests.cs
@@ -73,7 +73,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         [TestCase(PoolingType.Average, 1, 2, 1.5f)]
         public void TestUpdate_LargeWindow(PoolingType type, float input1, float input2, float output)
         {
-            var layer = new PoolingLayer(3, 3, type);
+            var layer = new PoolingLayer(2, 1, type);
             layer.Build(new Size1D(2));
             layer.OutputSize.Should().Be(new Size1D(1));
 
@@ -106,7 +106,6 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         [TestCase(11, 3)]
         [TestCase(12, 4)]
         [TestCase(9, 3)]
-        [TestCase(1, 1)]
         public void TestBuild(int inputSize, int expectedNodeCount)
         {
             var layer = new PoolingLayer(3, 3, PoolingType.Min);

--- a/NeuralNetworks.Test/Layers/PoolingLayerTests.cs
+++ b/NeuralNetworks.Test/Layers/PoolingLayerTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using Ivankarez.NeuralNetworks.Api;
 using Ivankarez.NeuralNetworks.Layers;
 using Ivankarez.NeuralNetworks.Utils;
 using NUnit.Framework;
@@ -11,8 +12,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_MaxPooling()
         {
             var layer = new PoolingLayer(3, 3, PoolingType.Max);
-            layer.Build(new Size1D(9));
-            layer.OutputSize.Should().Be(new Size1D(3));
+            layer.Build(NN.Size.Of(9));
+            layer.OutputSize.Should().Be(NN.Size.Of(3));
 
             var result = layer.Update(new float[] { 1f, 2f, 3f, 5f, 1f, 1f, -1f, -2f, -1f });
 
@@ -26,8 +27,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_MinPooling()
         {
             var layer = new PoolingLayer(3, 3, PoolingType.Min);
-            layer.Build(new Size1D(9));
-            layer.OutputSize.Should().Be(new Size1D(3));
+            layer.Build(NN.Size.Of(9));
+            layer.OutputSize.Should().Be(NN.Size.Of(3));
 
             var result = layer.Update(new float[] { 1f, 2f, 3f, 5f, 1f, 0f, -1f, -2f, -1f });
 
@@ -41,8 +42,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_SumPooling()
         {
             var layer = new PoolingLayer(3, 3, PoolingType.Sum);
-            layer.Build(new Size1D(9));
-            layer.OutputSize.Should().Be(new Size1D(3));
+            layer.Build(NN.Size.Of(9));
+            layer.OutputSize.Should().Be(NN.Size.Of(3));
 
             var result = layer.Update(new float[] { 1f, 2f, 3f, 5f, 1f, -2f, -1f, -2f, -1f });
 
@@ -56,8 +57,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_AvgPooling()
         {
             var layer = new PoolingLayer(3, 3, PoolingType.Average);
-            layer.Build(new Size1D(9));
-            layer.OutputSize.Should().Be(new Size1D(3));
+            layer.Build(NN.Size.Of(9));
+            layer.OutputSize.Should().Be(NN.Size.Of(3));
 
             var result = layer.Update(new float[] { 1f, 2f, 3f, 5f, 1f, -3f, -1f, -2f, -3f });
 
@@ -74,8 +75,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_LargeWindow(PoolingType type, float input1, float input2, float output)
         {
             var layer = new PoolingLayer(2, 1, type);
-            layer.Build(new Size1D(2));
-            layer.OutputSize.Should().Be(new Size1D(1));
+            layer.Build(NN.Size.Of(2));
+            layer.OutputSize.Should().Be(NN.Size.Of(1));
 
             var result = layer.Update(new float[] { input1, input2 });
 
@@ -90,8 +91,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_DifferentStrideAndWindow(PoolingType type, float[] input, float[] output)
         {
             var layer = new PoolingLayer(3, 1, type);
-            layer.Build(new Size1D(input.Length));
-            layer.OutputSize.Should().Be(new Size1D(output.Length));
+            layer.Build(NN.Size.Of(input.Length));
+            layer.OutputSize.Should().Be(NN.Size.Of(output.Length));
 
             var result = layer.Update(input);
 
@@ -110,12 +111,12 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         {
             var layer = new PoolingLayer(3, 3, PoolingType.Min);
 
-            layer.Build(new Size1D(inputSize));
+            layer.Build(NN.Size.Of(inputSize));
 
             layer.Parameters.Get1dVectorNames().Should().BeEmpty();
             layer.Parameters.Get2dVectorNames().Should().BeEmpty();
             layer.State.Get1dVector("nodeValues").Should().HaveCount(expectedNodeCount);
-            layer.OutputSize.Should().Be(new Size1D(expectedNodeCount));
+            layer.OutputSize.Should().Be(NN.Size.Of(expectedNodeCount));
         }
     }
 }

--- a/NeuralNetworks.Test/Layers/PoolingLayerTests.cs
+++ b/NeuralNetworks.Test/Layers/PoolingLayerTests.cs
@@ -11,8 +11,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_MaxPooling()
         {
             var layer = new PoolingLayer(3, 3, PoolingType.Max);
-            layer.Build(9);
-            layer.NodeCount.Should().Be(3);
+            layer.Build(new Size1D(9));
+            layer.OutputSize.Should().Be(new Size1D(3));
 
             var result = layer.Update(new float[] { 1f, 2f, 3f, 5f, 1f, 1f, -1f, -2f, -1f });
 
@@ -26,8 +26,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_MinPooling()
         {
             var layer = new PoolingLayer(3, 3, PoolingType.Min);
-            layer.Build(9);
-            layer.NodeCount.Should().Be(3);
+            layer.Build(new Size1D(9));
+            layer.OutputSize.Should().Be(new Size1D(3));
 
             var result = layer.Update(new float[] { 1f, 2f, 3f, 5f, 1f, 0f, -1f, -2f, -1f });
 
@@ -41,8 +41,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_SumPooling()
         {
             var layer = new PoolingLayer(3, 3, PoolingType.Sum);
-            layer.Build(9);
-            layer.NodeCount.Should().Be(3);
+            layer.Build(new Size1D(9));
+            layer.OutputSize.Should().Be(new Size1D(3));
 
             var result = layer.Update(new float[] { 1f, 2f, 3f, 5f, 1f, -2f, -1f, -2f, -1f });
 
@@ -56,8 +56,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_AvgPooling()
         {
             var layer = new PoolingLayer(3, 3, PoolingType.Average);
-            layer.Build(9);
-            layer.NodeCount.Should().Be(3);
+            layer.Build(new Size1D(9));
+            layer.OutputSize.Should().Be(new Size1D(3));
 
             var result = layer.Update(new float[] { 1f, 2f, 3f, 5f, 1f, -3f, -1f, -2f, -3f });
 
@@ -74,8 +74,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_LargeWindow(PoolingType type, float input1, float input2, float output)
         {
             var layer = new PoolingLayer(3, 3, type);
-            layer.Build(2);
-            layer.NodeCount.Should().Be(1);
+            layer.Build(new Size1D(2));
+            layer.OutputSize.Should().Be(new Size1D(1));
 
             var result = layer.Update(new float[] { input1, input2 });
 
@@ -83,15 +83,15 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
             result[0].Should().Be(output);
         }
 
-        [TestCase(PoolingType.Max, new float[] { 1, 2, 3, 4 }, new float[] { 3, 4 })]
-        [TestCase(PoolingType.Min, new float[] { 1, 2, 3, 4 }, new float[] { 1, 3 })]
-        [TestCase(PoolingType.Sum, new float[] { 1, 2, 3, 4 }, new float[] { 6, 7 })]
-        [TestCase(PoolingType.Average, new float[] { 1, 2, 3, 4 }, new float[] { 2, 3.5f })]
+        [TestCase(PoolingType.Max, new[] { 1f, 2, 3, 4 }, new[] { 3f, 4 })]
+        [TestCase(PoolingType.Min, new[] { 1f, 2, 3, 4 }, new[] { 1f, 2 })]
+        [TestCase(PoolingType.Sum, new[] { 1f, 2, 3, 4 }, new[] { 6f, 9 })]
+        [TestCase(PoolingType.Average, new[] { 1f, 2, 3, 4 }, new[] { 2f, 3 })]
         public void TestUpdate_DifferentStrideAndWindow(PoolingType type, float[] input, float[] output)
         {
-            var layer = new PoolingLayer(3, 2, type);
-            layer.Build(input.Length);
-            layer.NodeCount.Should().Be(output.Length);
+            var layer = new PoolingLayer(3, 1, type);
+            layer.Build(new Size1D(input.Length));
+            layer.OutputSize.Should().Be(new Size1D(output.Length));
 
             var result = layer.Update(input);
 
@@ -102,8 +102,8 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
             }
         }
 
-        [TestCase(10, 4)]
-        [TestCase(11, 4)]
+        [TestCase(10, 3)]
+        [TestCase(11, 3)]
         [TestCase(12, 4)]
         [TestCase(9, 3)]
         [TestCase(1, 1)]
@@ -111,12 +111,12 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         {
             var layer = new PoolingLayer(3, 3, PoolingType.Min);
 
-            layer.Build(inputSize);
+            layer.Build(new Size1D(inputSize));
 
             layer.Parameters.Get1dVectorNames().Should().BeEmpty();
             layer.Parameters.Get2dVectorNames().Should().BeEmpty();
             layer.State.Get1dVector("nodeValues").Should().HaveCount(expectedNodeCount);
-            layer.NodeCount.Should().Be(expectedNodeCount);
+            layer.OutputSize.Should().Be(new Size1D(expectedNodeCount));
         }
     }
 }

--- a/NeuralNetworks.Test/Layers/RecurrentLayerTests.cs
+++ b/NeuralNetworks.Test/Layers/RecurrentLayerTests.cs
@@ -16,7 +16,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_SingleCall()
         {
             var layer = new RecurrentLayer(2, new LinearActivation(), false, defaultInitializer, defaultInitializer, defaultInitializer);
-            layer.Build(1);
+            layer.Build(new Size1D(1));
             layer.Parameters.Get2dVector("weights").Fill(new float[,] { { 1 }, { -1 } });
             layer.Parameters.Get1dVector("recurrentWeights").Fill(.5f, -.5f);
             var result = layer.Update(new float[] { 1f });
@@ -32,7 +32,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_DoubleCall()
         {
             var layer = new RecurrentLayer(2, new LinearActivation(), false, defaultInitializer, defaultInitializer, defaultInitializer);
-            layer.Build(1);
+            layer.Build(new Size1D(1));
             layer.Parameters.Get2dVector("weights").Fill(new float[,] { { 1 }, { -1 } });
             layer.Parameters.Get1dVector("recurrentWeights").Fill(.5f, -.5f);
 
@@ -50,7 +50,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_HappyPathWithBias()
         {
             var layer = new RecurrentLayer(2, new LinearActivation(), true, defaultInitializer, defaultInitializer, defaultInitializer);
-            layer.Build(1);
+            layer.Build(new Size1D(1));
             layer.Parameters.Get2dVector("weights").Fill(new float[,] { { 1 }, { -1 } });
             layer.Parameters.Get1dVector("recurrentWeights").Fill(.5f, -.5f);
             layer.Parameters.Get1dVector("biases").Fill(10, 10);
@@ -72,7 +72,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
             var biasInitializer = new ConstantInitializer(3);
 
             var layer = new RecurrentLayer(2, new LinearActivation(), true, kernelInitializer, biasInitializer, recurrentInitializer);
-            layer.Build(1);
+            layer.Build(new Size1D(1));
 
             layer.Parameters.Get2dVector("weights").Should().BeEquivalentTo(new float[,] { { 1 }, { 1 } });
             layer.Parameters.Get1dVector("recurrentWeights").Should().BeEquivalentTo(new float[] { 2, 2 });

--- a/NeuralNetworks.Test/Layers/RecurrentLayerTests.cs
+++ b/NeuralNetworks.Test/Layers/RecurrentLayerTests.cs
@@ -16,7 +16,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_SingleCall()
         {
             var layer = new RecurrentLayer(2, new LinearActivation(), false, defaultInitializer, defaultInitializer, defaultInitializer);
-            layer.Build(new Size1D(1));
+            layer.Build(NN.Size.Of(1));
             layer.Parameters.Get2dVector("weights").Fill(new float[,] { { 1 }, { -1 } });
             layer.Parameters.Get1dVector("recurrentWeights").Fill(.5f, -.5f);
             var result = layer.Update(new float[] { 1f });
@@ -32,7 +32,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_DoubleCall()
         {
             var layer = new RecurrentLayer(2, new LinearActivation(), false, defaultInitializer, defaultInitializer, defaultInitializer);
-            layer.Build(new Size1D(1));
+            layer.Build(NN.Size.Of(1));
             layer.Parameters.Get2dVector("weights").Fill(new float[,] { { 1 }, { -1 } });
             layer.Parameters.Get1dVector("recurrentWeights").Fill(.5f, -.5f);
 
@@ -50,7 +50,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
         public void TestUpdate_HappyPathWithBias()
         {
             var layer = new RecurrentLayer(2, new LinearActivation(), true, defaultInitializer, defaultInitializer, defaultInitializer);
-            layer.Build(new Size1D(1));
+            layer.Build(NN.Size.Of(1));
             layer.Parameters.Get2dVector("weights").Fill(new float[,] { { 1 }, { -1 } });
             layer.Parameters.Get1dVector("recurrentWeights").Fill(.5f, -.5f);
             layer.Parameters.Get1dVector("biases").Fill(10, 10);
@@ -72,7 +72,7 @@ namespace Ivankarez.NeuralNetworks.Test.Layers
             var biasInitializer = new ConstantInitializer(3);
 
             var layer = new RecurrentLayer(2, new LinearActivation(), true, kernelInitializer, biasInitializer, recurrentInitializer);
-            layer.Build(new Size1D(1));
+            layer.Build(NN.Size.Of(1));
 
             layer.Parameters.Get2dVector("weights").Should().BeEquivalentTo(new float[,] { { 1 }, { 1 } });
             layer.Parameters.Get1dVector("recurrentWeights").Should().BeEquivalentTo(new float[] { 2, 2 });

--- a/NeuralNetworks.Test/Layers/RecurrentLayerTests.cs
+++ b/NeuralNetworks.Test/Layers/RecurrentLayerTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Ivankarez.NeuralNetworks.Abstractions;
 using Ivankarez.NeuralNetworks.Activations;
+using Ivankarez.NeuralNetworks.Api;
 using Ivankarez.NeuralNetworks.Layers;
 using Ivankarez.NeuralNetworks.RandomGeneration.Initializers;
 using Ivankarez.NeuralNetworks.Utils;

--- a/NeuralNetworks.Test/Utils/ConvolutionUtilsTests.cs
+++ b/NeuralNetworks.Test/Utils/ConvolutionUtilsTests.cs
@@ -1,0 +1,55 @@
+﻿using FluentAssertions;
+using Ivankarez.NeuralNetworks.Utils;
+using NUnit.Framework;
+using System;
+
+namespace Ivankarez.NeuralNetworks.Test.Utils
+{
+    public class ConvolutionUtilsTests
+    {
+        [TestCase(3, 1, 1, 3)]
+        [TestCase(3, 2, 1, 2)]
+        [TestCase(3, 3, 1, 1)]
+        [TestCase(3, 1, 2, 2)]
+        [TestCase(3, 2, 2, 1)]
+        [TestCase(3, 3, 2, 1)]
+        [TestCase(3, 1, 3, 1)]
+        public void TestCalculateOutputSize_HappyPath(int inputSize, int window, int stride, int expectedOutputSize)
+        {
+            var outputSize = ConvolutionUtils.CalculateOutputSize(inputSize, window, stride);
+            outputSize.Should().Be(expectedOutputSize);
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        public void TestCalculateOutputSize_InvalidInputSize(int inputSize)
+        {
+            Action testAction = () => ConvolutionUtils.CalculateOutputSize(inputSize, 1, 1);
+            testAction.Should().Throw<ArgumentException>().WithMessage("Input size must be greater than 0*");
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        public void TestCalculateOutputSize_InvalidWindow(int window)
+        {
+            Action testAction = () => ConvolutionUtils.CalculateOutputSize(1, window, 1);
+            testAction.Should().Throw<ArgumentException>().WithMessage("Window size must be greater than 0*");
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        public void TestCalculateOutputSize_InvalidStride(int stride)
+        {
+            Action testAction = () => ConvolutionUtils.CalculateOutputSize(1, 1, stride);
+            testAction.Should().Throw<ArgumentException>().WithMessage("Stride must be greater than 0*");
+        }
+
+        [TestCase(1, 2)]
+        [TestCase(2, 3)]
+        public void TestCalculateOutputSize_InvalidWindowGreaterThanInputSize(int inputSize, int window)
+        {
+            Action testAction = () => ConvolutionUtils.CalculateOutputSize(inputSize, window, 1);
+            testAction.Should().Throw<ArgumentException>().WithMessage("Window size must be less than input size*");
+        }
+    }
+}

--- a/NeuralNetworks/Abstractions/IModelLayer.cs
+++ b/NeuralNetworks/Abstractions/IModelLayer.cs
@@ -4,12 +4,12 @@ namespace Ivankarez.NeuralNetworks.Abstractions
 {
     public interface IModelLayer
     {
-        public int NodeCount { get; }
+        public ISize OutputSize { get; }
 
         public NamedVectors<float> Parameters { get; }
         public NamedVectors<float> State { get; }
 
-        public void Build(int inputSize);
+        public void Build(ISize inputSize);
 
         public float[] Update(float[] inputValues);
     }

--- a/NeuralNetworks/Abstractions/ISize.cs
+++ b/NeuralNetworks/Abstractions/ISize.cs
@@ -1,0 +1,9 @@
+﻿namespace Ivankarez.NeuralNetworks.Abstractions
+{
+    public interface ISize
+    {
+        public int Dimensions { get; }
+        public int this[int dimension] { get; }
+        public int TotalSize { get; }
+    }
+}

--- a/NeuralNetworks/Api/LayersApi.cs
+++ b/NeuralNetworks/Api/LayersApi.cs
@@ -68,21 +68,20 @@ namespace Ivankarez.NeuralNetworks.Api
         /// <summary>
         /// Creates and returns a 2D Convolutional Layer for a neural network.
         /// </summary>
-        /// <param name="inputSize">The size of the input feature map to the layer (width and height).</param>
         /// <param name="filterSize">The size of the convolutional filters in the layer (width and height).</param>
         /// <param name="stride">The horizontal and vertical stride for filter movement. Defaults to (1, 1).</param>
         /// <param name="useBias">A flag indicating whether bias terms should be used in the layer. Defaults to true.</param>
         /// <param name="kernelInitializer">The initializer for the filter kernels of the layer. Defaults to Glorot Uniform initialization.</param>
         /// <param name="biasInitializer">The initializer for bias terms of the layer. Defaults to initializing with zeros.</param>
         /// <returns>A 2D Convolutional Layer instance configured with the specified parameters.</returns>
-        public Convolutional2dLayer Conv2D(Size2D inputSize, Size2D filterSize, Stride2D stride = null,
+        public Convolutional2dLayer Conv2D(Size2D filterSize, Stride2D stride = null,
             bool useBias = true, IInitializer kernelInitializer = null, IInitializer biasInitializer = null)
         {
             kernelInitializer ??= NN.Initializers.GlorotUniform();
             biasInitializer ??= NN.Initializers.Zeros();
             stride ??= new Stride2D(1, 1);
 
-            return new Convolutional2dLayer(inputSize, filterSize, stride, useBias, kernelInitializer, biasInitializer);
+            return new Convolutional2dLayer(filterSize, stride, useBias, kernelInitializer, biasInitializer);
         }
 
         /// <summary>
@@ -100,16 +99,15 @@ namespace Ivankarez.NeuralNetworks.Api
         /// <summary>
         /// Creates and returns a 2D Pooling Layer for a neural network.
         /// </summary>
-        /// <param name="inputSize">The size of the input feature map to the layer (width and height).</param>
         /// <param name="windowSize">The size of the pooling window, which determines the area over which pooling is applied (width and height).</param>
         /// <param name="stride">The horizontal and vertical stride for pooling operations. Defaults to (1, 1).</param>
         /// <param name="poolingType">The type of pooling. Defaults to Max pooling.</param>
         /// <returns>A 2D Pooling Layer instance configured with the specified parameters.</returns>
-        public Pooling2dLayer Pooling2D(Size2D inputSize, Size2D windowSize, Stride2D stride = null, PoolingType poolingType = PoolingType.Max)
+        public Pooling2dLayer Pooling2D(Size2D windowSize, Stride2D stride = null, PoolingType poolingType = PoolingType.Max)
         {
             stride ??= new Stride2D(1, 1);
 
-            return new Pooling2dLayer(inputSize, windowSize, stride, poolingType);
+            return new Pooling2dLayer(windowSize, stride, poolingType);
         }
     }
 }

--- a/NeuralNetworks/Api/ModelsApi.cs
+++ b/NeuralNetworks/Api/ModelsApi.cs
@@ -1,4 +1,5 @@
 ﻿using Ivankarez.NeuralNetworks.Abstractions;
+using Ivankarez.NeuralNetworks.Utils;
 
 namespace Ivankarez.NeuralNetworks.Api
 {
@@ -13,6 +14,16 @@ namespace Ivankarez.NeuralNetworks.Api
         /// <param name="inputs">The number of input nodes to the network model.</param>
         /// <param name="layers">An array of IModelLayer instances representing the layers of the network model.</param>
         public LayeredNetworkModel Layered(int inputs, params IModelLayer[] layers)
+        {
+            return Layered(new Size1D(inputs), layers);
+        }
+
+        /// <summary>
+        /// Creates and returns a Layered Network Model, a composite neural network model consisting of multiple layers, with the specified number of input nodes and layers.
+        /// </summary>
+        /// <param name="inputs">The number of input nodes to the network model.</param>
+        /// <param name="layers">An array of IModelLayer instances representing the layers of the network model.</param>
+        public LayeredNetworkModel Layered(ISize inputs, params IModelLayer[] layers)
         {
             return new LayeredNetworkModel(inputs, layers);
         }

--- a/NeuralNetworks/Api/NN.cs
+++ b/NeuralNetworks/Api/NN.cs
@@ -29,5 +29,10 @@
         /// Gets an instance of the InitializersApi class, which provides access to various weight and bias initialization methods for neural network components.
         /// </summary>
         public static InitializersApi Initializers { get; } = new InitializersApi();
+
+        /// <summary>
+        /// Gets an instance of the SizeApi class, which provides access to size objects in different dimensions.
+        /// </summary>
+        public static SizeApi Size { get; } = new SizeApi();
     }
 }

--- a/NeuralNetworks/Api/SizeApi.cs
+++ b/NeuralNetworks/Api/SizeApi.cs
@@ -1,0 +1,30 @@
+﻿using Ivankarez.NeuralNetworks.Utils;
+
+namespace Ivankarez.NeuralNetworks.Api
+{
+    public class SizeApi
+    {
+        internal SizeApi() { }
+
+        /// <summary>
+        /// Creates a new instance of Size1D with the specified size.
+        /// </summary>
+        /// <param name="size">The size of the 1D dimension. Must be greater than 0.</param>
+        /// <returns>A new Size1D object with the specified size.</returns>
+        public Size1D Of(int size)
+        {
+            return new Size1D(size);
+        }
+
+        /// <summary>
+        /// Creates a new instance of Size2D with the specified width and height.
+        /// </summary>
+        /// <param name="width">The width of the 2D size. Must be greater than 0.</param>
+        /// <param name="height">The height of the 2D size. Must be greater than 0.</param>
+        /// <returns>A new Size2D object with the specified width and height.</returns>
+        public Size2D Of(int width, int height)
+        {
+            return new Size2D(width, height);
+        }
+    }
+}

--- a/NeuralNetworks/LayeredNetworkModel.cs
+++ b/NeuralNetworks/LayeredNetworkModel.cs
@@ -9,11 +9,11 @@ namespace Ivankarez.NeuralNetworks
         private readonly IModelLayer[] layers;
 
         public IReadOnlyList<IModelLayer> Layers => layers;
-        public int Inputs { get; }
+        public ISize Inputs { get; }
 
-        public LayeredNetworkModel(int inputs, params IModelLayer[] layers)
+        public LayeredNetworkModel(ISize inputs, params IModelLayer[] layers)
         {
-            if (inputs <= 0) throw new ArgumentOutOfRangeException(nameof(inputs), "Must be bigger than 0");
+            if (inputs.TotalSize <= 0) throw new ArgumentOutOfRangeException(nameof(inputs), "Total size must be bigger than 0");
             if (layers.Length == 0) throw new ArgumentException("Must have at least 1 element", nameof(layers));
 
             Inputs = inputs;
@@ -28,13 +28,13 @@ namespace Ivankarez.NeuralNetworks
             foreach (var layer in layers)
             {
                 layer.Build(inputSize);
-                inputSize = layer.NodeCount;
+                inputSize = layer.OutputSize;
             }
         }
 
         public float[] Feedforward(float[] inputValues)
         {
-            if (inputValues.Length != Inputs) throw new ArgumentException($"Must have length of {Inputs}", nameof(inputValues));
+            if (inputValues.Length != Inputs.TotalSize) throw new ArgumentException($"Must have length of {Inputs}", nameof(inputValues));
 
             var layerInputs = inputValues;
             foreach (var layer in layers)

--- a/NeuralNetworks/Layers/Convolutional2dLayer.cs
+++ b/NeuralNetworks/Layers/Convolutional2dLayer.cs
@@ -27,18 +27,13 @@ namespace Ivankarez.NeuralNetworks.Layers
         public Convolutional2dLayer(Size2D filterSize, Stride2D stride,
             bool useBias, IInitializer kernelInitializer, IInitializer biasInitializer)
         {
-            if (filterSize == null) throw new ArgumentNullException(nameof(filterSize));
-            if (stride == null) throw new ArgumentNullException(nameof(stride));
-            if (kernelInitializer == null) throw new ArgumentNullException(nameof(kernelInitializer));
-            if (biasInitializer == null) throw new ArgumentNullException(nameof(biasInitializer));
-
             Parameters = new NamedVectors<float>();
             State = new NamedVectors<float>();
-            FilterSize = filterSize;
-            Stride = stride;
+            FilterSize = filterSize ?? throw new ArgumentNullException(nameof(filterSize));
+            Stride = stride ?? throw new ArgumentNullException(nameof(stride));
             UseBias = useBias;
-            KernelInitializer = kernelInitializer;
-            BiasInitializer = biasInitializer;
+            KernelInitializer = kernelInitializer ?? throw new ArgumentNullException(nameof(kernelInitializer));
+            BiasInitializer = biasInitializer ?? throw new ArgumentNullException(nameof(biasInitializer));
         }
 
         public void Build(ISize inputSize)

--- a/NeuralNetworks/Layers/ConvolutionalLayer.cs
+++ b/NeuralNetworks/Layers/ConvolutionalLayer.cs
@@ -25,14 +25,11 @@ namespace Ivankarez.NeuralNetworks.Layers
         {
             if (filterSize < 1) throw new ArgumentException("Filter size must be greater than 0", nameof(filterSize));
             if (stride < 1) throw new ArgumentException("Stride must be greater than 0", nameof(stride));
-            if (kernelInitializer == null) throw new ArgumentNullException(nameof(kernelInitializer));
-            if (biasInitializer == null) throw new ArgumentNullException(nameof(biasInitializer));
-
             FilterSize = filterSize;
             Stride = stride;
             UseBias = useBias;
-            KernelInitializer = kernelInitializer;
-            BiasInitializer = biasInitializer;
+            KernelInitializer = kernelInitializer ?? throw new ArgumentNullException(nameof(kernelInitializer));
+            BiasInitializer = biasInitializer ?? throw new ArgumentNullException(nameof(biasInitializer));
             Parameters = new NamedVectors<float>();
             State = new NamedVectors<float>();
         }

--- a/NeuralNetworks/Layers/DenseLayer.cs
+++ b/NeuralNetworks/Layers/DenseLayer.cs
@@ -24,10 +24,8 @@ namespace Ivankarez.NeuralNetworks.Layers
         public DenseLayer(int nodeCount, IActivation activation, bool useBias, IInitializer kernelInitializer, IInitializer biasInitializer)
         {
             if (nodeCount <= 0) throw new ArgumentOutOfRangeException(nameof(nodeCount), "Must be bigger than zero");
-            if (activation == null) throw new ArgumentNullException(nameof(activation));
-
             OutputSize = new Size1D(nodeCount);
-            this.activation = activation;
+            this.activation = activation ?? throw new ArgumentNullException(nameof(activation));
             this.useBias = useBias;
             KernelInitializer = kernelInitializer;
             BiasInitializer = biasInitializer;

--- a/NeuralNetworks/Layers/DenseLayer.cs
+++ b/NeuralNetworks/Layers/DenseLayer.cs
@@ -1,5 +1,6 @@
 ﻿using Ivankarez.NeuralNetworks.Abstractions;
 using Ivankarez.NeuralNetworks.RandomGeneration;
+using Ivankarez.NeuralNetworks.Utils;
 using Ivankarez.NeuralNetworks.Values;
 using System;
 
@@ -7,7 +8,7 @@ namespace Ivankarez.NeuralNetworks.Layers
 {
     public class DenseLayer : IModelLayer
     {
-        public int NodeCount { get; }
+        public ISize OutputSize { get; }
         public IInitializer KernelInitializer { get; }
         public IInitializer BiasInitializer { get; }
         public NamedVectors<float> Parameters { get; }
@@ -25,7 +26,7 @@ namespace Ivankarez.NeuralNetworks.Layers
             if (nodeCount <= 0) throw new ArgumentOutOfRangeException(nameof(nodeCount), "Must be bigger than zero");
             if (activation == null) throw new ArgumentNullException(nameof(activation));
 
-            NodeCount = nodeCount;
+            OutputSize = new Size1D(nodeCount);
             this.activation = activation;
             this.useBias = useBias;
             KernelInitializer = kernelInitializer;
@@ -34,11 +35,11 @@ namespace Ivankarez.NeuralNetworks.Layers
             State = new NamedVectors<float>();
         }
 
-        public void Build(int inputSize)
+        public void Build(ISize inputSize)
         {
-            weights = KernelInitializer.GenerateValues2d(inputSize, NodeCount, NodeCount, inputSize);
-            nodeValues = new float[NodeCount];
-            biases = useBias ? BiasInitializer.GenerateValues(inputSize, NodeCount, NodeCount) : new float[0];
+            weights = KernelInitializer.GenerateValues2d(inputSize.TotalSize, OutputSize.TotalSize, OutputSize.TotalSize, inputSize.TotalSize);
+            nodeValues = new float[OutputSize.TotalSize];
+            biases = useBias ? BiasInitializer.GenerateValues(inputSize.TotalSize, OutputSize.TotalSize, OutputSize.TotalSize) : new float[0];
 
             State.Add("nodeValues", nodeValues);
             Parameters.Add("biases", biases);
@@ -47,7 +48,7 @@ namespace Ivankarez.NeuralNetworks.Layers
 
         public float[] Update(float[] inputValues)
         {
-            for (int nodeIndex = 0; nodeIndex < NodeCount; nodeIndex++)
+            for (int nodeIndex = 0; nodeIndex < OutputSize.TotalSize; nodeIndex++)
             {
                 UpdateNode(nodeIndex, inputValues);
             }

--- a/NeuralNetworks/Layers/Pooling2dLayer.cs
+++ b/NeuralNetworks/Layers/Pooling2dLayer.cs
@@ -22,11 +22,8 @@ namespace Ivankarez.NeuralNetworks.Layers
 
         public Pooling2dLayer(Size2D windowSize, Stride2D stride, PoolingType poolingType)
         {
-            if (windowSize == null) throw new ArgumentNullException(nameof(windowSize));
-            if (stride == null) throw new ArgumentNullException(nameof(stride));
-
-            WindowSize = windowSize;
-            Stride = stride;
+            WindowSize = windowSize ?? throw new ArgumentNullException(nameof(windowSize));
+            Stride = stride ?? throw new ArgumentNullException(nameof(stride));
             PoolingType = poolingType;
             pooling = GetPooling();
 

--- a/NeuralNetworks/Layers/Pooling2dLayer.cs
+++ b/NeuralNetworks/Layers/Pooling2dLayer.cs
@@ -7,10 +7,10 @@ namespace Ivankarez.NeuralNetworks.Layers
 {
     public class Pooling2dLayer : IModelLayer
     {
-        public int NodeCount { get; private set; }
+        public ISize OutputSize { get; private set; }
+        public Size2D InputSize { get; set; }
         public NamedVectors<float> Parameters { get; }
         public NamedVectors<float> State { get; }
-        public Size2D InputSize { get; }
         public Size2D WindowSize { get; }
         public Stride2D Stride { get; }
         public PoolingType PoolingType { get; }
@@ -20,15 +20,11 @@ namespace Ivankarez.NeuralNetworks.Layers
         private int nodeValuesWidth;
         private int nodeValuesHeight;
 
-        public Pooling2dLayer(Size2D inputSize, Size2D windowSize, Stride2D stride, PoolingType poolingType)
+        public Pooling2dLayer(Size2D windowSize, Stride2D stride, PoolingType poolingType)
         {
-            if (inputSize == null) throw new ArgumentNullException(nameof(inputSize));
             if (windowSize == null) throw new ArgumentNullException(nameof(windowSize));
             if (stride == null) throw new ArgumentNullException(nameof(stride));
-            if (windowSize.Width > inputSize.Width) throw new ArgumentException("Filter width cannot be greater than input width", nameof(windowSize.Width));
-            if (windowSize.Height > inputSize.Height) throw new ArgumentException("Filter height cannot be greater than input height", nameof(windowSize.Height));
 
-            InputSize = inputSize;
             WindowSize = windowSize;
             Stride = stride;
             PoolingType = poolingType;
@@ -38,15 +34,15 @@ namespace Ivankarez.NeuralNetworks.Layers
             State = new NamedVectors<float>();
         }
 
-        public void Build(int inputSize)
+        public void Build(ISize inputSize)
         {
-            var expectedInputSize = InputSize.Width * InputSize.Height;
-            if (inputSize != expectedInputSize) throw new ArgumentException($"Input size must be {expectedInputSize}", nameof(inputSize));
+            if (!(inputSize is Size2D)) throw new ArgumentException($"Input size must be {nameof(Size2D)}", nameof(inputSize));
+            InputSize = inputSize as Size2D;
 
-            nodeValuesWidth = (InputSize.Width - WindowSize.Width) / Stride.Horizontal + 1;
-            nodeValuesHeight = (InputSize.Height - WindowSize.Height) / Stride.Vertical + 1;
-            NodeCount = nodeValuesWidth * nodeValuesHeight;
-            nodeValues = new float[NodeCount];
+            nodeValuesWidth = ConvolutionUtils.CalculateOutputSize(InputSize.Width, WindowSize.Width, Stride.Horizontal);
+            nodeValuesHeight = ConvolutionUtils.CalculateOutputSize(InputSize.Height, WindowSize.Height, Stride.Vertical);
+            OutputSize = new Size2D(nodeValuesWidth, nodeValuesHeight);
+            nodeValues = new float[OutputSize.TotalSize];
 
             State.Add("nodeValues", nodeValues);
         }

--- a/NeuralNetworks/Layers/PoolingLayer.cs
+++ b/NeuralNetworks/Layers/PoolingLayer.cs
@@ -7,7 +7,7 @@ namespace Ivankarez.NeuralNetworks.Layers
 {
     public class PoolingLayer : IModelLayer
     {
-        public int NodeCount { get; private set; }
+        public ISize OutputSize { get; private set; }
         public int Window { get; }
         public int Stride { get; }
         public PoolingType Type { get; }
@@ -24,16 +24,15 @@ namespace Ivankarez.NeuralNetworks.Layers
             Window = window;
             Stride = stride;
             Type = type;
-            NodeCount = -1;
 
             Parameters = new NamedVectors<float>();
             State = new NamedVectors<float>();
         }
 
-        public void Build(int inputSize)
+        public void Build(ISize inputSize)
         {
-            NodeCount = (int)Math.Ceiling((double)inputSize / Stride);
-            nodeValues = new float[NodeCount];
+            OutputSize = new Size1D(ConvolutionUtils.CalculateOutputSize(inputSize.TotalSize, Window, Stride));
+            nodeValues = new float[OutputSize.TotalSize];
             State.Add("nodeValues", nodeValues);
         }
 

--- a/NeuralNetworks/Layers/RecurrentLayer.cs
+++ b/NeuralNetworks/Layers/RecurrentLayer.cs
@@ -26,17 +26,12 @@ namespace Ivankarez.NeuralNetworks.Layers
         public RecurrentLayer(int nodeCount, IActivation activation, bool useBias, IInitializer kernelInitializer, IInitializer biasInitializer, IInitializer recurrentInitializer)
         {
             if (nodeCount <= 0) throw new ArgumentOutOfRangeException(nameof(nodeCount), "Must be bigger than zero");
-            if (activation == null) throw new ArgumentNullException(nameof(activation));
-            if (kernelInitializer == null) throw new ArgumentNullException(nameof(kernelInitializer));
-            if (biasInitializer == null) throw new ArgumentNullException(nameof(biasInitializer));
-            if (recurrentInitializer == null) throw new ArgumentNullException(nameof(recurrentInitializer));
-
             OutputSize = new Size1D(nodeCount);
-            this.activation = activation;
+            this.activation = activation ?? throw new ArgumentNullException(nameof(activation));
             this.useBias = useBias;
-            KernelInitializer = kernelInitializer;
-            BiasInitializer = biasInitializer;
-            RecurrentInitializer = recurrentInitializer;
+            KernelInitializer = kernelInitializer ?? throw new ArgumentNullException(nameof(kernelInitializer));
+            BiasInitializer = biasInitializer ?? throw new ArgumentNullException(nameof(biasInitializer));
+            RecurrentInitializer = recurrentInitializer ?? throw new ArgumentNullException(nameof(recurrentInitializer));
             Parameters = new NamedVectors<float>();
             State = new NamedVectors<float>();
         }

--- a/NeuralNetworks/Layers/RecurrentLayer.cs
+++ b/NeuralNetworks/Layers/RecurrentLayer.cs
@@ -1,5 +1,6 @@
 ﻿using Ivankarez.NeuralNetworks.Abstractions;
 using Ivankarez.NeuralNetworks.RandomGeneration;
+using Ivankarez.NeuralNetworks.Utils;
 using Ivankarez.NeuralNetworks.Values;
 using System;
 
@@ -7,7 +8,7 @@ namespace Ivankarez.NeuralNetworks.Layers
 {
     public class RecurrentLayer : IModelLayer
     {
-        public int NodeCount { get; }
+        public ISize OutputSize { get; }
         public IInitializer KernelInitializer { get; }
         public IInitializer BiasInitializer { get; }
         public IInitializer RecurrentInitializer { get; }
@@ -30,7 +31,7 @@ namespace Ivankarez.NeuralNetworks.Layers
             if (biasInitializer == null) throw new ArgumentNullException(nameof(biasInitializer));
             if (recurrentInitializer == null) throw new ArgumentNullException(nameof(recurrentInitializer));
 
-            NodeCount = nodeCount;
+            OutputSize = new Size1D(nodeCount);
             this.activation = activation;
             this.useBias = useBias;
             KernelInitializer = kernelInitializer;
@@ -40,12 +41,12 @@ namespace Ivankarez.NeuralNetworks.Layers
             State = new NamedVectors<float>();
         }
 
-        public void Build(int inputSize)
+        public void Build(ISize inputSize)
         {
-            weights = KernelInitializer.GenerateValues2d(inputSize, NodeCount, NodeCount, inputSize);
-            recurrentWeights = RecurrentInitializer.GenerateValues(inputSize, NodeCount, NodeCount);
-            biases = useBias ? BiasInitializer.GenerateValues(inputSize, NodeCount, NodeCount) : new float[0];
-            nodeValues = new float[NodeCount];
+            weights = KernelInitializer.GenerateValues2d(inputSize.TotalSize, OutputSize.TotalSize, OutputSize.TotalSize, inputSize.TotalSize);
+            recurrentWeights = RecurrentInitializer.GenerateValues(inputSize.TotalSize, OutputSize.TotalSize, OutputSize.TotalSize);
+            biases = useBias ? BiasInitializer.GenerateValues(inputSize.TotalSize, OutputSize.TotalSize, OutputSize.TotalSize) : new float[0];
+            nodeValues = new float[OutputSize.TotalSize];
 
             State.Add("nodeValues", nodeValues);
             Parameters.Add("biases", biases);
@@ -55,7 +56,7 @@ namespace Ivankarez.NeuralNetworks.Layers
 
         public float[] Update(float[] inputValues)
         {
-            for (int nodeIndex = 0; nodeIndex < NodeCount; nodeIndex++)
+            for (int nodeIndex = 0; nodeIndex < OutputSize.TotalSize; nodeIndex++)
             {
                 UpdateNode(nodeIndex, inputValues);
             }

--- a/NeuralNetworks/RandomGeneration/Initializers/GlorotNormalInitializer.cs
+++ b/NeuralNetworks/RandomGeneration/Initializers/GlorotNormalInitializer.cs
@@ -9,9 +9,7 @@ namespace Ivankarez.NeuralNetworks.RandomGeneration.Initializers
 
         public GlorotNormalInitializer(IRandomProvider randomProvider) 
         {
-            if (randomProvider == null) throw new ArgumentNullException(nameof(randomProvider));
-
-            RandomProvider = randomProvider;
+            RandomProvider = randomProvider ?? throw new ArgumentNullException(nameof(randomProvider));
         }
 
         public float GenerateValue(int fanIn, int fanOut)

--- a/NeuralNetworks/RandomGeneration/Initializers/GlorotUniformInitializer.cs
+++ b/NeuralNetworks/RandomGeneration/Initializers/GlorotUniformInitializer.cs
@@ -9,9 +9,7 @@ namespace Ivankarez.NeuralNetworks.RandomGeneration.Initializers
 
         public GlorotUniformInitializer(IRandomProvider randomProvider) 
         {
-            if (randomProvider == null) throw new ArgumentNullException(nameof(randomProvider));
-
-            RandomProvider = randomProvider;
+            RandomProvider = randomProvider ?? throw new ArgumentNullException(nameof(randomProvider));
         }
 
         public float GenerateValue(int fanIn, int fanOut)

--- a/NeuralNetworks/RandomGeneration/SystemRandomProvider.cs
+++ b/NeuralNetworks/RandomGeneration/SystemRandomProvider.cs
@@ -9,9 +9,7 @@ namespace Ivankarez.NeuralNetworks.RandomGeneration
 
         public SystemRandomProvider(Random random)
         {
-            if (random == null) throw new ArgumentNullException(nameof(random));
-
-            Random = random;
+            Random = random ?? throw new ArgumentNullException(nameof(random));
         }
 
         public float NextFloat()

--- a/NeuralNetworks/Utils/ConvolutionUtils.cs
+++ b/NeuralNetworks/Utils/ConvolutionUtils.cs
@@ -1,9 +1,16 @@
-﻿namespace Ivankarez.NeuralNetworks.Utils
+﻿using System;
+
+namespace Ivankarez.NeuralNetworks.Utils
 {
     public static class ConvolutionUtils
     {
         public static int CalculateOutputSize(int inputSize, int window, int stride)
         {
+            if (inputSize <= 0) throw new ArgumentException("Input size must be greater than 0", nameof(inputSize));
+            if (window <= 0) throw new ArgumentException("Window size must be greater than 0", nameof(window));
+            if (stride <= 0) throw new ArgumentException("Stride must be greater than 0", nameof(stride));
+            if (inputSize < window) throw new ArgumentException("Window size must be less than input size", nameof(window));
+
             return (inputSize - window) / stride + 1;
         }
     }

--- a/NeuralNetworks/Utils/ConvolutionUtils.cs
+++ b/NeuralNetworks/Utils/ConvolutionUtils.cs
@@ -1,0 +1,10 @@
+﻿namespace Ivankarez.NeuralNetworks.Utils
+{
+    public static class ConvolutionUtils
+    {
+        public static int CalculateOutputSize(int inputSize, int window, int stride)
+        {
+            return (inputSize - window) / stride + 1;
+        }
+    }
+}

--- a/NeuralNetworks/Utils/Size1D.cs
+++ b/NeuralNetworks/Utils/Size1D.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Ivankarez.NeuralNetworks.Abstractions;
+
+namespace Ivankarez.NeuralNetworks.Utils
+{
+    public class Size1D : ISize
+    {
+        public int this[int dimension]
+        {
+            get
+            {
+                if (dimension == 0) return TotalSize;
+                throw new IndexOutOfRangeException($"Dimension {dimension} is not valid on Size1D");
+            }
+        }
+
+        public int Dimensions => 1;
+
+        public int TotalSize { get; }
+
+        public Size1D(int size)
+        {
+            if (size <= 0) throw new ArgumentException("Size must be a positive integer.", nameof(size));
+            TotalSize = size;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is Size1D size && TotalSize == size.TotalSize;
+        }
+
+        public override int GetHashCode()
+        {
+            return TotalSize.GetHashCode();
+        }
+    }
+}

--- a/NeuralNetworks/Utils/Size2D.cs
+++ b/NeuralNetworks/Utils/Size2D.cs
@@ -1,11 +1,24 @@
 ﻿using System;
+using Ivankarez.NeuralNetworks.Abstractions;
 
 namespace Ivankarez.NeuralNetworks.Utils
 {
-    public class Size2D
+    public class Size2D : ISize
     {
+        public int Dimensions => 2;
+        public int TotalSize { get; }
         public int Width { get; }
         public int Height { get; }
+
+        public int this[int dimension]
+        {
+            get
+            {
+                if (dimension == 0) return Width;
+                if (dimension == 1) return Height;
+                throw new IndexOutOfRangeException($"Dimension {dimension} is not valid on Size2D");
+            }
+        }
 
         public Size2D(int width, int height)
         {
@@ -14,6 +27,7 @@ namespace Ivankarez.NeuralNetworks.Utils
 
             Width = width;
             Height = height;
+            TotalSize = width * height;
         }
 
         public static implicit operator Size2D((int, int) tuple)
@@ -24,6 +38,22 @@ namespace Ivankarez.NeuralNetworks.Utils
         public static implicit operator Size2D(int size)
         {
             return new Size2D(size, size);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is Size2D size && Equals(size);
+        }
+
+        public bool Equals(Size2D other)
+        {
+            return Width == other.Width &&
+                   Height == other.Height;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Width, Height);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Sample code to create layered model with 3 dense layers. The node count of the l
 ```C#
 using Ivankarez.NeuralNetworks.Api;
 
-var neuralNetwork = NN.Models.Layered(3,
+var neuralNetwork = NN.Models.Layered(NN.Size.Of(3),
         NN.Layers.Dense(10),
         NN.Layers.Dense(3, activation: NN.Activations.Tanh()),
         NN.Layers.Dense(2));
@@ -84,6 +84,10 @@ This is a simple list of available features of this package. If you look for ava
 - Normal
 - Glorot uniform
 - Glorot normal
+
+### [Size](https://github.com/ivankarez/NeuralNetworks/blob/main/NeuralNetworks/Api/SizeApi.cs)
+- *Of(int)*: Create a Size1D object
+- *Of(int, int)*: Create a Size2D object
 
 ## Contributions
 All contributions are welcome. For a starting point it's quite easy to implement other activation functions and initializers. Also extending test coverage, or simplify tests can be a good starting point.


### PR DESCRIPTION
The main point of this ticket was to remove the size parameter from the constructor of 2D layers, but I also unified and fixed output size calculations of layers with a rolling window. (Conv, Pooling)